### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/go-server/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: daily
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: 
+      interval: daily


### PR DESCRIPTION
Purpose of this PR is to add support for dependabot to track Go, NPM and Github-Action dependencies for updates.

For example the go-server is using gofiber `v2.40.0` instead of `v2.40.1`